### PR TITLE
Null-terminate a UTF8 string

### DIFF
--- a/src/url.swift
+++ b/src/url.swift
@@ -275,6 +275,7 @@ public extension String {
                 break
             }
         }
+        result.append(0)
         return String(validatingUTF8: result)
     }
 }


### PR DESCRIPTION
Unfortunately, the constructor `validatingUTF8` needs to be taken out
and shot.  It secretly takes an UnsafePointer to an array, which Swift
happily implicitly supplies.  However it does not know the array length
anymore, so it expects the data to be null-terminated.  When it isn't,
UB ensues.

IMO this is a very bad sharp edge in the stdlib and should be fixed.  I
have complained on the list many times, I will complain again in
response to this incident.

https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160418/015404.html
