### PR TITLE
Various file-related issues

### DIFF
--- a/src/filesystem/file.swift
+++ b/src/filesystem/file.swift
@@ -27,7 +27,7 @@ public class File {
     private(set) public var path: Path?
 
     /// take ownership of the file descriptor/pointer
-    private let closeWhenDeallocated: Bool
+    private var closeWhenDeallocated: Bool
 
     /// File mode
     public enum Mode:String {
@@ -85,12 +85,13 @@ public class File {
             openMode += "b"
         }
         self.path = path
-        self.closeWhenDeallocated = true
 
+        self.closeWhenDeallocated = false
         self.fp = fopen(path.description, openMode)
         if self.fp == nil {
             throw errnoToError(errno: errno)
         }
+        self.closeWhenDeallocated = true
     }
 
     /// Initialize with a file descriptor

--- a/src/logger.swift
+++ b/src/logger.swift
@@ -157,7 +157,7 @@ public class Log {
 
     private class func _fwrite(_ stream: UnsafeMutablePointer<FILE>, _ data: String) {
         let buf = [CChar].fromString(data)
-        fwrite(buf, buf.count, 1, stream)
+        fwrite(buf, buf.count - 1, 1, stream)
     }
 
     /// Only use class functions please

--- a/tests/filesystem/fs.swift
+++ b/tests/filesystem/fs.swift
@@ -184,7 +184,7 @@ class FSTests: XCTestCase {
             XCTAssert(FS.fileExists(path: p) == true)
             let gid = try FS.getGroup(path: p)
             #if os(Linux)
-                let everyone = try FS.resolveGroup(name: "nobody")
+                let everyone = try FS.resolveGroup(name: "nogroup")
             #else
                 let everyone = try FS.resolveGroup(name: "everyone")
             #endif

--- a/tests/filesystem/fs.swift
+++ b/tests/filesystem/fs.swift
@@ -183,7 +183,11 @@ class FSTests: XCTestCase {
             try FS.touchItem(path: p)
             XCTAssert(FS.fileExists(path: p) == true)
             let gid = try FS.getGroup(path: p)
-            let everyone = try FS.resolveGroup(name: "everyone")
+            #if os(Linux)
+                let everyone = try FS.resolveGroup(name: "nobody")
+            #else
+                let everyone = try FS.resolveGroup(name: "everyone")
+            #endif
             XCTAssertNotNil(everyone)
             try FS.setGroup(path: p, newGroup: everyone!)
             let newGroup = try FS.getGroup(path: p)

--- a/tests/filesystem/fs.swift
+++ b/tests/filesystem/fs.swift
@@ -197,6 +197,11 @@ class FSTests: XCTestCase {
         }
     }
 
+    func testLoadNonexistentFile() {
+        let p = Path("doesnotexist.file")
+        let _ = try? File(path: p, mode: .ReadOnly)
+    }
+
 }
 
 extension FSTests {
@@ -214,7 +219,8 @@ extension FSTests {
             ("testChmodFile", testChmodFile),
             ("testResolveGroup", testResolveGroup),
             ("testResolveUser", testResolveUser),
-            ("testSetGroup", testSetGroup)
+            ("testSetGroup", testSetGroup),
+            ("testLoadNonexistentFile", testLoadNonexistentFile)
         ]
     }
 }

--- a/tests/filesystem/path.swift
+++ b/tests/filesystem/path.swift
@@ -171,7 +171,7 @@ class PathTests: XCTestCase {
     func testHomeDir() {
         if let p = Path.homeDirectory() {
 #if os(Linux)
-            XCTAssert(p.components.count >= 2, "Home dir has \(p.comonents.count) components")
+            XCTAssert(p.components.count >= 2, "Home dir has \(p.components.count) components")
             // disabled because CI has something other than /home/ci
             // if p.components.count >= 2 {
             //     XCTAssert(p.components[0] == "home")

--- a/tests/filesystem/path.swift
+++ b/tests/filesystem/path.swift
@@ -171,7 +171,7 @@ class PathTests: XCTestCase {
     func testHomeDir() {
         if let p = Path.homeDirectory() {
 #if os(Linux)
-            XCTAssert(p.components.count >= 2, "Home dir has \(p.components.count) components")
+            XCTAssert(p.components.count > 0, "Home dir has \(p.components.count) components")
             // disabled because CI has something other than /home/ci
             // if p.components.count >= 2 {
             //     XCTAssert(p.components[0] == "home")

--- a/tests/filesystem/path.swift
+++ b/tests/filesystem/path.swift
@@ -171,10 +171,11 @@ class PathTests: XCTestCase {
     func testHomeDir() {
         if let p = Path.homeDirectory() {
 #if os(Linux)
-            XCTAssert(p.components.count == 2)
-            if p.components.count >= 2 {
-                XCTAssert(p.components[0] == "home")
-            }
+            XCTAssert(p.components.count >= 2, "Home dir has \(p.comonents.count) components")
+            // disabled because CI has something other than /home/ci
+            // if p.components.count >= 2 {
+            //     XCTAssert(p.components[0] == "home")
+            // }
             XCTAssert(p.isAbsolute == true)
 #else
             XCTAssert(p.components.count == 2)

--- a/tests/main.swift
+++ b/tests/main.swift
@@ -25,4 +25,5 @@ XCTMain([
     testCase(PathTests.allTests),
     testCase(DateTests.allTests),
     testCase(LoggerTests.allTests),
+    testCase(FSTests.allTests)
 ])


### PR DESCRIPTION
This PR exposes various issues in the filesubsystem, to wit:
1.  File tests were not enabled.  I enabled them; now some of them fail
2.  I added a new test that loads a non-existent file
3.  The above-styled test segfaults in libc on Linux x64
   
   ```
   * thread #1: tid = 14, 0x00007ffff64b75e4 libc.so.6`fclose + 4, name = 'atbuild', stop reason = signal SIGSEGV: invalid address (fault address: 0x0)
   * frame #0: 0x00007ffff64b75e4 libc.so.6`fclose + 4
   ```
4.  This segfault is the root cause of the CI failure in
   https://github.com/AnarchyTools/atbuild/pull/88
