### PR TITLE
Update to swift-DEVELOPMENT-SNAPSHOT-2016-05-03-a

### DIFF
--- a/src/string/replace.swift
+++ b/src/string/replace.swift
@@ -21,8 +21,8 @@ public extension String {
     /// - parameter replacement: replacement
     /// - returns: new string with substituted range
     public func replacing(range: Range<String.Index>, replacement: String) -> String {
-        let before = self.subString(range: self.startIndex..<range.startIndex)
-        let after = self.subString(range: range.endIndex..<self.endIndex)
+        let before = self.subString(range: self.startIndex..<range.lowerBound)
+        let after = self.subString(range: range.upperBound..<self.endIndex)
         return String.join(parts: [before, after], delimiter: replacement)
     }
 
@@ -36,10 +36,7 @@ public extension String {
             return self
         }
         let comps = self.split(string: searchTerm)
-        var replaced = String.join(parts: comps, delimiter: replacement)
-        if self.hasSuffix(searchTerm) {
-            replaced = replaced.subString(toIndex: replaced.endIndex.advanced(by: -searchTerm.characters.count)) + replacement
-        }
+        let replaced = String.join(parts: comps, delimiter: replacement)
         return replaced
     }
 

--- a/src/string/search.swift
+++ b/src/string/search.swift
@@ -23,19 +23,20 @@ public extension String {
     /// - returns: `String.Index` if character was found or `nil`
     public func position(character: Character, index: String.Index? = nil, reverse: Bool = false) -> String.Index? {
         if reverse {
-            var i = (index == nil) ? self.endIndex.predecessor() : index!
+            var i = (index == nil) ? self.index(before: self.endIndex) : index!
             while i >= self.startIndex {
                 if self.characters[i] == character {
                     return i
                 }
-                i = i.predecessor()
+                i = self.index(before: i)
             }
         } else {
-            let start = (index == nil) ? self.startIndex : index!
-            for i in start..<self.endIndex {
+            var i = (index == nil) ? self.startIndex : index!
+            while i < self.endIndex {
                 if self.characters[i] == character {
                     return i
                 }
+                i = self.index(after: i)
             }
         }
         return nil
@@ -50,7 +51,7 @@ public extension String {
         var p = self.position(character: character)
         while p != nil  {
             result.append(p!)
-            p = self.position(character: character, index: p!.successor())
+            p = self.position(character: character, index: self.index(after: p!))
         }
         return result
     }
@@ -68,13 +69,13 @@ public extension String {
         }
 
         if reverse {
-            if index != nil && self.startIndex.distance(to: index!) < string.characters.count {
+            if index != nil && self.distance(from: startIndex, to: index!) < string.characters.count {
                 // can not find match because string is too short for match
                 return nil
             }
 
             // start with index/self.endIndex and go back
-            var i = (index == nil) ? self.endIndex.advanced(by: -string.characters.count) : index!
+            var i = (index == nil) ?  self.index(endIndex, offsetBy:  -string.characters.count) : index!
             while i >= self.startIndex {
 
                 var idx = i
@@ -86,22 +87,22 @@ public extension String {
                         match = false
                         break
                     }
-                    idx = idx.successor()
+                    idx = self.index(after: idx)
                 }
                 if match {
                     return i
                 }
-                i = i.predecessor()
+                i = self.index(before: i)
             }
         } else {
-            if index != nil && index!.distance(to: self.endIndex) < string.characters.count {
+            if index != nil && self.distance(from: index!, to: self.endIndex) < string.characters.count {
                 // can not find match because string is too short for match
                 return nil
             }
             let start = (index == nil) ? self.startIndex : index!
-
+            var i = start
             // iterate from start to end - search string length
-            for i in start..<self.endIndex.advanced(by: -string.characters.count) {
+            while i < endIndex {
                 var idx = i
 
                 // compare substring
@@ -111,11 +112,12 @@ public extension String {
                         match = false
                         break
                     }
-                    idx = idx.successor()
+                    idx = self.index(after: idx)
                 }
                 if match {
                     return i
                 }
+                i = self.index(after: i)
             }
         }
         return nil
@@ -130,7 +132,7 @@ public extension String {
         var p = self.position(string: string)
         while p != nil  {
             result.append(p!)
-            p = self.position(string: string, index: p!.successor())
+            p = self.position(string: string, index: self.index(after: p!))
         }
         return result
     }
@@ -171,23 +173,23 @@ public extension String {
         }
 
         // quick check if first and last char match
-        if self.characters.first! == prefix.characters.first! && self.characters[self.startIndex.advanced(by: prefix.characters.count - 1)] == prefix.characters.last! {
+        if self.characters.first! == prefix.characters.first! && self.characters[self.index(self.startIndex, offsetBy: prefix.characters.count - 1)] == prefix.characters.last! {
             // if prefix length == 2 instantly return true
             if prefix.characters.count == 2 {
                 return true
             }
 
             // match, thorough check
-            var selfIndex = self.startIndex.successor()
-            var prefixIndex = prefix.startIndex.successor()
+            var selfIndex = self.index(after:self.startIndex)
+            var prefixIndex = prefix.index(after:prefix.startIndex)
 
             // first and last already checked
             for _ in 1..<(prefix.characters.count - 1) {
                 if self.characters[selfIndex] != prefix.characters[prefixIndex] {
                     return false
                 }
-                selfIndex = selfIndex.successor()
-                prefixIndex = prefixIndex.successor()
+                selfIndex = self.index(after: selfIndex)
+                prefixIndex = prefix.index(after: prefixIndex)
             }
             return true
         }
@@ -213,23 +215,23 @@ public extension String {
         }
 
         // quick check if first and last char match
-        if self.characters.last! == suffix.characters.last! && self.characters[self.startIndex.advanced(by: self.characters.count - suffix.characters.count)] == suffix.characters.first! {
+        if self.characters.last! == suffix.characters.last! && self.characters[self.index(self.startIndex, offsetBy: self.characters.count - suffix.characters.count)] == suffix.characters.first! {
             // if suffix length == 2 instantly return true
             if suffix.characters.count == 2 {
                 return true
             }
 
             // match, thorough check
-            var selfIndex = self.startIndex.advanced(by: self.characters.count - suffix.characters.count + 1)
-            var suffixIndex = suffix.startIndex.successor()
+            var selfIndex = self.index(self.startIndex, offsetBy: self.characters.count - suffix.characters.count + 1)
+            var suffixIndex = suffix.index(after: suffix.startIndex)
 
             // first and last already checked
             for _ in 1..<(suffix.characters.count - 1) {
                 if self.characters[selfIndex] != suffix.characters[suffixIndex] {
                     return false
                 }
-                selfIndex = selfIndex.successor()
-                suffixIndex = suffixIndex.successor()
+                selfIndex = self.index(after: selfIndex)
+                suffixIndex = suffix.index(after: suffixIndex)
             }
             return true
         }

--- a/src/string/split.swift
+++ b/src/string/split.swift
@@ -136,11 +136,10 @@ public extension String {
     public func split(string: String, maxSplits: Int = 0) -> [String] {
         var result = [String]()
         let positions = self.positions(string: string)
-
         var start = self.startIndex
         for idx in positions {
             result.append(self.subString(range: start..<idx))
-            start = idx.advanced(by: string.characters.count)
+            start = self.index(idx, offsetBy: string.characters.count)
             if result.count == maxSplits {
                 break
             }

--- a/src/string/substring.swift
+++ b/src/string/substring.swift
@@ -21,9 +21,10 @@ public extension String {
     /// - returns: substring or `nil` if start index out of range
     public func subString(range: Range<String.Index>) -> String {
         var result = ""
-        result.reserveCapacity(range.count)
-        for idx in range {
-            result.append(self.characters[idx])
+
+        result.reserveCapacity(self.distance(from: range.upperBound, to: range.lowerBound))
+        for char in self.characters[range.lowerBound..<range.upperBound] {
+            result.append(char)
         }
         return result
     }

--- a/src/string/whitespace.swift
+++ b/src/string/whitespace.swift
@@ -18,22 +18,24 @@ public extension String {
     ///
     /// - returns: trimmed string
     public func stringByTrimmingWhitespace() -> String {
-        var startIndex:String.CharacterView.Index = self.startIndex
-        for (index, c) in self.characters.enumerated() {
+        var startIndex = self.characters.startIndex
+        var index = self.characters.startIndex
+        for c in self.characters {
             if !Charset.isUnicodeWhitespaceOrNewline(character: c) {
-                startIndex = self.startIndex.advanced(by: index)
+                startIndex = index
                 break
             }
+            index = self.index(after: index)
         }
 
-        var endIndex = self.endIndex.advanced(by: -1)
+        var endIndex = self.characters.index(before: self.characters.endIndex)
         for _ in 0..<self.characters.count {
             if !Charset.isUnicodeWhitespaceOrNewline(character: self.characters[endIndex]) {
                 break
             }
-            endIndex = endIndex.advanced(by: -1)
+            endIndex = self.characters.index(before: endIndex)
         }
 
-        return self.subString(range: startIndex...endIndex)
+        return self.subString(range: startIndex..<self.characters.index(after: endIndex))
     }
 }

--- a/src/url.swift
+++ b/src/url.swift
@@ -276,11 +276,12 @@ public extension String {
         while true {
             let c = self[index]
             if c == "%" {
-                if let highIndex = dict.index(of: self[index.advanced(by: 1)]), let lowIndex = dict.index(of: self[index.advanced(by: 2)]) {
+
+                if let highIndex = dict.index(of: self[self.index(after: index)]), let lowIndex = dict.index(of: self[self.index(index, offsetBy: 2)]) {
                     let high = Int8(truncatingBitPattern: dict.startIndex.distance(to: highIndex))
                     let low = Int8(truncatingBitPattern: dict.startIndex.distance(to: lowIndex))
                     result.append(high << 4 + low)
-                    index = index.advanced(by: 2)
+                    index = self.index(index, offsetBy: 2)
                 } else {
                     let s = String(c)
                     for item in s.utf8 {
@@ -294,7 +295,7 @@ public extension String {
                 }
             }
 
-            index = index.successor()
+            index = self.index(after: index)
             if index == self.endIndex {
                 break
             }

--- a/tests/string/replace.swift
+++ b/tests/string/replace.swift
@@ -37,12 +37,12 @@ class ReplaceTests: XCTestCase {
 
     func testNewStringRange() {
         let s = "Hello World!"
-        XCTAssert(s.replacing(range: s.startIndex.advanced(by: 6)..<s.startIndex.advanced(by: 6+5), replacement: "You") == "Hello You!")
+        XCTAssert(s.replacing(range: s.index(s.startIndex, offsetBy: 6)..<s.index(s.startIndex, offsetBy: 6+5), replacement: "You") == "Hello You!")
     }
 
     func testNewStringRangeWithEmpty() {
         let s = "Hello World!"
-        XCTAssert(s.replacing(range: s.startIndex.advanced(by: 5)..<s.startIndex.advanced(by: 6+5), replacement: "") == "Hello!")
+        XCTAssert(s.replacing(range: s.index(s.startIndex, offsetBy: 5)..<s.index(s.startIndex, offsetBy: 6+5), replacement: "") == "Hello!")
     }
 
     func testNewStringReplacingEnd() {
@@ -72,13 +72,13 @@ class ReplaceTests: XCTestCase {
 
     func testModifyRange() {
         var s = "Hello World!"
-        s.replace(range: s.startIndex.advanced(by: 6)..<s.startIndex.advanced(by: 6+5), replacement: "You")
+        s.replace(range: s.index(s.startIndex, offsetBy: 6)..<s.index(s.startIndex, offsetBy: 6+5), replacement: "You")
         XCTAssert(s == "Hello You!")
     }
 
     func testModifyRangeWithEmpty() {
         var s = "Hello World!"
-        s.replace(range: s.startIndex.advanced(by: 5)..<s.startIndex.advanced(by: 6+5), replacement: "")
+        s.replace(range: s.index(s.startIndex, offsetBy: 5)..<s.index(s.startIndex, offsetBy: 6+5), replacement: "")
         XCTAssert(s == "Hello!")
     }
 

--- a/tests/string/search.swift
+++ b/tests/string/search.swift
@@ -23,7 +23,7 @@ class SearchTests: XCTestCase {
         let c: Character = "."
         let s = "Just a string with a . in it"
         if let result = s.position(character: c) {
-            XCTAssert(s.startIndex.advanced(by: 21) == result)
+            XCTAssert(s.index(s.startIndex, offsetBy: 21) == result)
         } else {
             XCTFail(". not found")
         }
@@ -41,7 +41,7 @@ class SearchTests: XCTestCase {
         let c: Character = "i"
         let s = "Just a string with a . in it"
         if let result = s.position(character: c, reverse: true) {
-            XCTAssert(s.startIndex.advanced(by: 26) == result)
+            XCTAssert(s.index(s.startIndex, offsetBy: 26) == result)
         } else {
             XCTFail("i not found")
         }
@@ -50,8 +50,8 @@ class SearchTests: XCTestCase {
     func testPositionOfCharStartIndex() {
         let c: Character = "i"
         let s = "Just a string with a . in it"
-        if let result = s.position(character: c, index: s.startIndex.advanced(by: 22)) {
-            XCTAssert(s.startIndex.advanced(by: 23) == result)
+        if let result = s.position(character: c, index: s.index(s.startIndex, offsetBy: 22)) {
+            XCTAssert(s.index(s.startIndex, offsetBy: 23) == result)
         } else {
             XCTFail("i not found")
         }
@@ -60,8 +60,8 @@ class SearchTests: XCTestCase {
     func testPositionOfCharStartIndexReverse() {
         let c: Character = "i"
         let s = "Just a string with a . in it"
-        if let result = s.position(character: c, index: s.startIndex.advanced(by: 25), reverse: true) {
-            XCTAssert(s.startIndex.advanced(by: 23) == result)
+        if let result = s.position(character: c, index: s.index(s.startIndex, offsetBy: 25), reverse: true) {
+            XCTAssert(s.index(s.startIndex, offsetBy: 23) == result)
         } else {
             XCTFail("i not found")
         }
@@ -73,10 +73,10 @@ class SearchTests: XCTestCase {
         let result = s.positions(character: c)
         XCTAssert(result.count == 4)
         if result.count == 4 {
-            XCTAssert(result[0] == s.startIndex.advanced(by: 10))
-            XCTAssert(result[1] == s.startIndex.advanced(by: 15))
-            XCTAssert(result[2] == s.startIndex.advanced(by: 23))
-            XCTAssert(result[3] == s.startIndex.advanced(by: 26))
+            XCTAssert(result[0] == s.index(s.startIndex, offsetBy: 10))
+            XCTAssert(result[1] == s.index(s.startIndex, offsetBy: 15))
+            XCTAssert(result[2] == s.index(s.startIndex, offsetBy: 23))
+            XCTAssert(result[3] == s.index(s.startIndex, offsetBy: 26))
         }
     }
 
@@ -93,7 +93,7 @@ class SearchTests: XCTestCase {
         let n = "a "
         let s = "Just a string with a . in it"
         if let result = s.position(string: n) {
-            XCTAssert(s.startIndex.advanced(by: 5) == result)
+            XCTAssert(s.index(s.startIndex, offsetBy: 5) == result)
         } else {
             XCTFail("'a ' not found")
         }
@@ -111,7 +111,7 @@ class SearchTests: XCTestCase {
         let n = "a "
         let s = "Just a string with a . in it"
         if let result = s.position(string: n, reverse: true) {
-            XCTAssert(s.startIndex.advanced(by: 19) == result)
+            XCTAssert(s.index(s.startIndex, offsetBy: 19) == result)
         } else {
             XCTFail("'a ' not found")
         }
@@ -120,8 +120,8 @@ class SearchTests: XCTestCase {
     func testPositionOfStringStartIndex() {
         let n = "a "
         let s = "Just a string with a . in it"
-        if let result = s.position(string: n, index: s.startIndex.advanced(by: 10)) {
-            XCTAssert(s.startIndex.advanced(by: 19) == result)
+        if let result = s.position(string: n, index: s.index(s.startIndex, offsetBy: 10)) {
+            XCTAssert(s.index(s.startIndex, offsetBy: 19) == result)
         } else {
             XCTFail("'a ' not found")
         }
@@ -130,8 +130,8 @@ class SearchTests: XCTestCase {
     func testPositionOfStringStartIndexReverse() {
         let n = "a "
         let s = "Just a string with a . in it"
-        if let result = s.position(string: n, index: s.startIndex.advanced(by: 10), reverse: true) {
-            XCTAssert(s.startIndex.advanced(by: 5) == result)
+        if let result = s.position(string: n, index: s.index(s.startIndex, offsetBy: 10), reverse: true) {
+            XCTAssert(s.index(s.startIndex, offsetBy: 5) == result)
         } else {
             XCTFail("'a ' not found")
         }
@@ -143,8 +143,8 @@ class SearchTests: XCTestCase {
         let result = s.positions(string: n)
         XCTAssert(result.count == 2)
         if result.count == 2 {
-            XCTAssert(result[0] == s.startIndex.advanced(by: 5))
-            XCTAssert(result[1] == s.startIndex.advanced(by: 19))
+            XCTAssert(result[0] == s.index(s.startIndex, offsetBy:  5))
+            XCTAssert(result[1] == s.index(s.startIndex, offsetBy:  19))
         }
     }
 

--- a/tests/string/substring.swift
+++ b/tests/string/substring.swift
@@ -20,7 +20,7 @@ class SubstringTests: XCTestCase {
 
     func testSubstring() {
         let s = "Extract (a rather unimportant) substring"
-        let substring = s.subString(range: s.startIndex.advanced(by: 8)...s.startIndex.advanced(by: 29))
+        let substring = s.subString(range: s.index(s.startIndex, offsetBy: 8)..<s.index(s.startIndex, offsetBy: 30))
         XCTAssert(substring == "(a rather unimportant)")
     }
 
@@ -32,13 +32,13 @@ class SubstringTests: XCTestCase {
 
     func testSubstringToIndex() {
         let s = "Extract (a rather unimportant) substring"
-        let substring = s.subString(toIndex: s.startIndex.advanced(by: 8))
+        let substring = s.subString(toIndex: s.index(s.startIndex, offsetBy: 8))
         XCTAssert(substring == "Extract ")
     }
 
     func testSubstringFromIndex() {
         let s = "Extract (a rather unimportant) substring"
-        let substring = s.subString(fromIndex: s.startIndex.advanced(by: 8))
+        let substring = s.subString(fromIndex: s.index(s.startIndex, offsetBy: 8))
         XCTAssert(substring == "(a rather unimportant) substring")
     }
 }


### PR DESCRIPTION
This implements SE-0065, which was implemented in the latest snapshot.

https://github.com/apple/swift-evolution/blob/master/proposals/0065-collections-move-indices.md

Mostly this consists of changing stuff that used to operate on indexes
(such as successor, predecessor, etc.) to work on the collections
themselves.
